### PR TITLE
Add support for appending a single css file outside

### DIFF
--- a/packages/vitest-preview/src/node/previewServer.ts
+++ b/packages/vitest-preview/src/node/previewServer.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url';
 import { openBrowser } from '@vitest-preview/dev-utils';
 
 import { CACHE_FOLDER } from '../constants';
-import { createCacheFolderIfNeeded } from '../utils';
+import { createCacheFolderIfNeeded, getCssFileConfig } from '../utils';
 
 // TODO: Find the available port
 const port = process.env.PORT || 5006;
@@ -21,6 +21,12 @@ const emptyHtml = fs.readFileSync(
   'utf-8',
 );
 fs.writeFileSync(path.join(CACHE_FOLDER, 'index.html'), emptyHtml);
+
+const cssFile = getCssFileConfig();
+if (cssFile) {
+  console.log('copying css file', cssFile, 'into cache folder');
+  fs.copyFileSync(cssFile, path.join(CACHE_FOLDER, '__vitest-preview.css'));
+}
 
 async function createServer() {
   const app = express();
@@ -58,6 +64,9 @@ async function createServer() {
   });
 
   app.use(vite.middlewares);
+  if (cssFile) {
+    app.use('/__vitest-preview.css', express.static(path.join(CACHE_FOLDER, '__vitest-preview.css')));
+  }
 
   app.use('*', async (req, res, next) => {
     const url = req.originalUrl;

--- a/packages/vitest-preview/src/preview.ts
+++ b/packages/vitest-preview/src/preview.ts
@@ -1,10 +1,21 @@
 import fs from 'fs';
 import path from 'path';
 import { CACHE_FOLDER } from './constants';
-import { createCacheFolderIfNeeded } from './utils';
+import { createCacheFolderIfNeeded, getCssFileConfig } from './utils';
 
 export function debug(): void {
   createCacheFolderIfNeeded();
+
+  const cssFile = getCssFileConfig();
+  if (cssFile) {
+    const head = document.documentElement.querySelector('head');
+    if (head) {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = '/__vitest-preview.css';
+      head.appendChild(link);
+    }
+  }
 
   fs.writeFileSync(
     path.join(CACHE_FOLDER, 'index.html'),

--- a/packages/vitest-preview/src/utils.ts
+++ b/packages/vitest-preview/src/utils.ts
@@ -9,3 +9,10 @@ export function createCacheFolderIfNeeded() {
     });
   }
 }
+
+export function getCssFileConfig() {
+  const commandLineArgs = process.argv.slice(2);
+  const cssFile = commandLineArgs.find((arg) => arg.startsWith('--css='))?.split('=')[1] || null;
+
+  return cssFile;
+}


### PR DESCRIPTION

## Summary/ Motivation (TLDR;)

I want to load a single css file that is generated outside of the testrun.

This pr adds a --css=file option that copies in the file when starting the testserver.

## Related issues
- #37



## Features

- [x] Adds the --css=/path/to/file.css option when starting vitest-preview.

## Fixes

- [x]  #37
