### PR TITLE
feat: add `configure` `externalCss`

### DIFF
--- a/examples/react-testing-library/src/App.css
+++ b/examples/react-testing-library/src/App.css
@@ -3,7 +3,6 @@
 }
 
 .App-header {
-  background-color: #282c34;
   min-height: 100vh;
   display: flex;
   flex-direction: column;

--- a/examples/react-testing-library/src/background.css
+++ b/examples/react-testing-library/src/background.css
@@ -1,0 +1,3 @@
+body {
+  background-color: #282c34;
+}

--- a/examples/react-testing-library/src/main.tsx
+++ b/examples/react-testing-library/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
+import './background.css';
 import App from './App';
 
 ReactDOM.render(

--- a/examples/react-testing-library/src/test/setup.ts
+++ b/examples/react-testing-library/src/test/setup.ts
@@ -1,6 +1,9 @@
 import '@testing-library/jest-dom';
-
-
+import { configure } from 'vitest-preview';
 
 // Import global css to use with vitest-preview
 import '../index.css';
+
+configure({
+  externalCss: ['src/background.css'],
+});

--- a/packages/vitest-preview/package.json
+++ b/packages/vitest-preview/package.json
@@ -52,8 +52,10 @@
   "license": "MIT",
   "dependencies": {
     "@types/express": "^5.0.3",
+    "@types/jsdom": "^21.1.7",
     "@vitest-preview/dev-utils": "workspace:*",
     "express": "^5.1.0",
+    "jsdom": "^27.0.0",
     "vite": "^7.1.6"
   },
   "devDependencies": {

--- a/packages/vitest-preview/src/configure.ts
+++ b/packages/vitest-preview/src/configure.ts
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import path from 'path';
+import { CACHE_FOLDER } from './constants';
+import { createCacheFolderIfNeeded } from './utils';
+
+export interface ConfigureOptions {
+  externalCss?: string[];
+}
+
+export interface Config {
+  externalCss?: string[];
+}
+
+const CONFIG_FILE_NAME = 'vitest-preview.config.json';
+const configPath = path.join(CACHE_FOLDER, CONFIG_FILE_NAME);
+
+export function configure(options: ConfigureOptions) {
+  if (options.externalCss) {
+    // Check if the file exists
+    options.externalCss.forEach((cssFile) => {
+      if (!fs.existsSync(cssFile)) {
+        throw new Error(`File ${path.resolve(cssFile)} does not exist
+Please check your Vitest Preview configuration.
+Make sure externalCss path is relative to your current working directory`);
+      }
+    });
+  }
+  createCacheFolderIfNeeded();
+  fs.writeFileSync(configPath, JSON.stringify(options));
+}
+
+export function loadConfig(): Config {
+  if (fs.existsSync(configPath)) {
+    return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  }
+  return {};
+}

--- a/packages/vitest-preview/src/constants.ts
+++ b/packages/vitest-preview/src/constants.ts
@@ -1,7 +1,13 @@
 import path from 'path';
 import os from 'os';
 
-export const CACHE_FOLDER = path.join(os.tmpdir(), 'vitest-preview');
+const base64CurrentLocation = Buffer.from(process.cwd()).toString('base64url');
+
+export const CACHE_FOLDER = path.join(
+  os.tmpdir(),
+  'vitest-preview',
+  base64CurrentLocation,
+);
 
 export const green = '\x1b[32m';
 export const bold = '\x1b[1m';

--- a/packages/vitest-preview/src/index.ts
+++ b/packages/vitest-preview/src/index.ts
@@ -1,7 +1,4 @@
+import { configure } from './configure';
 import { debug } from './preview';
 
-export { debug };
-
-export default {
-  debug,
-};
+export { debug, configure };

--- a/packages/vitest-preview/src/utils.ts
+++ b/packages/vitest-preview/src/utils.ts
@@ -2,7 +2,6 @@ import fs from 'fs';
 import os from 'os';
 import { CACHE_FOLDER } from './constants';
 
-// Create cache folder if it doesn't exist
 export function createCacheFolderIfNeeded() {
   if (!fs.existsSync(CACHE_FOLDER)) {
     fs.mkdirSync(CACHE_FOLDER, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,12 +271,18 @@ importers:
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.3
+      '@types/jsdom':
+        specifier: ^21.1.7
+        version: 21.1.7
       '@vitest-preview/dev-utils':
         specifier: workspace:*
         version: link:../dev-utils
       express:
         specifier: ^5.1.0
         version: 5.1.0
+      jsdom:
+        specifier: ^27.0.0
+        version: 27.0.0(postcss@8.5.6)
       vite:
         specifier: ^7.1.6
         version: 7.1.6(@types/node@20.19.15)
@@ -1708,6 +1714,9 @@ packages:
   '@types/http-errors@2.0.4':
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
 
+  '@types/jsdom@21.1.7':
+    resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
+
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
@@ -1757,6 +1766,9 @@ packages:
 
   '@types/serve-static@1.15.7':
     resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@vitejs/plugin-react@4.3.1':
     resolution: {integrity: sha512-m/V2syj5CuVnaxcUJOQRel/Wr31FFXRFlnOoq1TVtkCxsY5veGMTEmpWHndrhB2U8ScHtCQB1e+4hWYExQc6Lg==}
@@ -2069,10 +2081,6 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  agent-base@7.1.1:
-    resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
-    engines: {node: '>= 14'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -5403,6 +5411,12 @@ snapshots:
 
   '@types/http-errors@2.0.4': {}
 
+  '@types/jsdom@21.1.7':
+    dependencies:
+      '@types/node': 20.19.15
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+
   '@types/mime@1.3.5': {}
 
   '@types/node@12.20.55': {}
@@ -5452,6 +5466,8 @@ snapshots:
       '@types/http-errors': 2.0.4
       '@types/node': 20.19.15
       '@types/send': 0.17.4
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@vitejs/plugin-react@4.3.1(vite@7.1.6(@types/node@20.19.15))':
     dependencies:
@@ -6103,12 +6119,6 @@ snapshots:
       negotiator: 1.0.0
 
   acorn@8.15.0: {}
-
-  agent-base@7.1.1:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -6828,8 +6838,8 @@ snapshots:
 
   http-proxy-agent@7.0.2:
     dependencies:
-      agent-base: 7.1.1
-      debug: 4.3.5
+      agent-base: 7.1.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 

--- a/website/docs/.vitepress/config.ts
+++ b/website/docs/.vitepress/config.ts
@@ -121,6 +121,20 @@ function sidebarGuide() {
       ],
     },
     {
+      text: 'APIs',
+      collapsible: true,
+      items: [
+        {
+          text: 'debug',
+          link: '/guide/api/debug',
+        },
+        {
+          text: 'configure',
+          link: '/guide/api/configure',
+        },
+      ],
+    },
+    {
       text: 'Examples',
       collapsible: true,
       items: [
@@ -156,6 +170,20 @@ function sidebarGuideCN() {
           link: '/zh/guide/what-is-vitest-preview',
         },
         { text: '起步', link: '/zh/guide/getting-started' },
+      ],
+    },
+    {
+      text: 'APIs',
+      collapsible: true,
+      items: [
+        {
+          text: 'debug',
+          link: '/zh/guide/api/debug',
+        },
+        {
+          text: 'configure',
+          link: '/zh/guide/api/configure',
+        },
       ],
     },
     {

--- a/website/docs/guide/api/configure.md
+++ b/website/docs/guide/api/configure.md
@@ -37,6 +37,7 @@ configure({
 
 - You typically want to call `configure` once in your test setup file
 - Make sure paths in `externalCss` are relative to your current working directory (usually the project root)
+- Vitest Preview Dashboard will not refresh automatically if `externalCss` files are changed. You need manually refresh the dashboard to see the changes.
 - It is encounraged to configure external CSS by importing them directly in your test setup file instead. By doing that, your CSS files will be processed by Vite and included in the preview.
 
 ```ts

--- a/website/docs/guide/api/configure.md
+++ b/website/docs/guide/api/configure.md
@@ -1,0 +1,50 @@
+# configure
+
+The `configure` function allows you to customize the behavior of Vitest Preview by providing configuration options.
+
+## Usage
+
+```ts
+// setup.ts or setup.js
+import { configure } from 'vitest-preview';
+
+configure({
+  externalCss: [
+    './styles/global.css',
+    './public/index.css',
+    './node_modules/@your-ui-lib/dist/styles.css',
+  ],
+});
+```
+
+## Options
+
+### `externalCss`
+
+An array of strings representing paths to CSS files that should be included in the preview. These paths should be relative to your current working directory, not your test setup file.
+
+```ts
+configure({
+  externalCss: [
+    './styles/global.css',
+    './public/index.css',
+    './node_modules/@your-ui-lib/dist/styles.css',
+  ],
+});
+```
+
+## Notes
+
+- You typically want to call `configure` once in your test setup file
+- Make sure paths in `externalCss` are relative to your current working directory (usually the project root)
+- It is encounraged to configure external CSS by importing them directly in your test setup file instead. By doing that, your CSS files will be processed by Vite and included in the preview.
+
+```ts
+// setup.ts or setup.js
+import { configure } from 'vitest-preview';
+
+// Should import CSS files directly in your test setup file
+import './styles/global.css';
+import './public/index.css';
+import './node_modules/@your-ui-lib/dist/styles.css';
+```

--- a/website/docs/guide/api/debug.md
+++ b/website/docs/guide/api/debug.md
@@ -1,0 +1,24 @@
+# debug
+
+The `debug` function is the core API of Vitest Preview. It captures the current state of the DOM and makes it available for preview in the browser.
+
+## Usage
+
+```ts
+import { debug } from 'vitest-preview';
+
+test('renders correctly', () => {
+  render(<YourComponent />);
+
+  // Call debug to capture the current DOM state
+  debug();
+});
+```
+
+This captured HTML can then be viewed in the browser through the Vitest Preview server, allowing you to visually inspect the rendered component.
+
+## Notes
+
+- Call `debug()` at the point in your test where you want to capture the DOM state
+- You can call `debug()` multiple times in a test to capture different states
+- The preview will show the most recent debug call's output

--- a/website/docs/guide/getting-started.md
+++ b/website/docs/guide/getting-started.md
@@ -14,12 +14,21 @@ If you are using Jest, you can try [jest-preview](https://github.com/nvh95/jest-
 
 ## Step 1: Installation
 
-```bash
+::: code-group
+
+```bash [npm]
 npm install --save-dev vitest-preview
-# Or
+```
+
+```bash [Yarn]
 yarn add -D vitest-preview
+```
+
+```bash [pnpm]
 pnpm add -D vitest-preview
 ```
+
+:::
 
 ## Step 2: Configuration
 
@@ -83,11 +92,20 @@ describe('App', () => {
 
 Open the **Vitest Preview Dashboard** by running the CLI command (updated in [Configuration](#step-2-configuration)):
 
-```bash
+::: code-group
+
+```bash [npm]
 npm run vitest-preview
-# Or
+```
+
+```bash [Yarn]
 yarn vitest-preview
+```
+
+```bash [pnpm]
 pnpm vitest-preview
 ```
+
+:::
 
 Then execute your tests that contain `debug()`. You will see the UI of your tests at localhost:5006.

--- a/website/docs/zh/guide/api/configure.md
+++ b/website/docs/zh/guide/api/configure.md
@@ -1,0 +1,50 @@
+# configure
+
+`configure` 函数允许你通过提供配置选项来自定义 Vitest Preview 的行为。
+
+## 用法
+
+```ts
+// setup.ts 或 setup.js
+import { configure } from 'vitest-preview';
+
+configure({
+  externalCss: [
+    './styles/global.css',
+    './public/index.css',
+    './node_modules/@your-ui-lib/dist/styles.css',
+  ],
+});
+```
+
+## 选项
+
+### `externalCss`
+
+一个字符串数组，表示应包含在预览中的 CSS 文件的路径。这些路径应相对于你的当前工作目录，而不是你的测试设置文件。
+
+```ts
+configure({
+  externalCss: [
+    './styles/global.css',
+    './public/index.css',
+    './node_modules/@your-ui-lib/dist/styles.css',
+  ],
+});
+```
+
+## 注意事项
+
+- 你通常希望在测试设置文件中调用一次 `configure`
+- 确保 `externalCss` 中的路径相对于你的当前工作目录（通常是项目根目录）
+- 建议直接在测试设置文件中导入外部 CSS。这样，你的 CSS 文件将由 Vite 处理并包含在预览中。
+
+```ts
+// setup.ts 或 setup.js
+import { configure } from 'vitest-preview';
+
+// 应该直接在测试设置文件中导入 CSS 文件
+import './styles/global.css';
+import './public/index.css';
+import './node_modules/@your-ui-lib/dist/styles.css';
+```

--- a/website/docs/zh/guide/api/configure.md
+++ b/website/docs/zh/guide/api/configure.md
@@ -37,6 +37,7 @@ configure({
 
 - 你通常希望在测试设置文件中调用一次 `configure`
 - 确保 `externalCss` 中的路径相对于你的当前工作目录（通常是项目根目录）
+- 当 `externalCss` 文件发生变化时，Vitest Preview 面板不会自动刷新。你需要手动刷新面板才能看到变化。
 - 建议直接在测试设置文件中导入外部 CSS。这样，你的 CSS 文件将由 Vite 处理并包含在预览中。
 
 ```ts

--- a/website/docs/zh/guide/api/debug.md
+++ b/website/docs/zh/guide/api/debug.md
@@ -1,0 +1,25 @@
+# debug
+
+`debug` 函数是 Vitest Preview 的核心 API。它捕获 DOM 的当前状态，并使其可在浏览器中预览。
+
+## 用法
+
+```ts
+import { debug } from 'vitest-preview';
+
+test('正确渲染', () => {
+  render(<YourComponent />);
+
+  // 调用 debug 捕获当前 DOM 状态
+  debug();
+});
+```
+
+
+然后可以通过 Vitest Preview 服务器在浏览器中查看捕获的 HTML，使你能够直观地检查渲染的组件。
+
+## 注意事项
+
+- 在测试中你想要捕获 DOM 状态的点调用 `debug()`
+- 你可以在测试中多次调用 `debug()` 以捕获不同的状态
+- 预览将显示最近一次 debug 调用的输出

--- a/website/docs/zh/guide/getting-started.md
+++ b/website/docs/zh/guide/getting-started.md
@@ -14,12 +14,21 @@
 
 ## Step 1: 安装
 
-```bash
+::: code-group
+
+```bash [npm]
 npm install --save-dev vitest-preview
-# 或者
+```
+
+```bash [Yarn]
 yarn add -D vitest-preview
+```
+
+```bash [pnpm]
 pnpm add -D vitest-preview
 ```
+
+:::
 
 ## Step 2: 配置
 
@@ -83,11 +92,20 @@ describe('App', () => {
 
 执行以下命令来打开 **Vitest Preview 面板** (你可以在 [配置](#step-2-configuration) 中自定义命令):
 
-```bash
+::: code-group
+
+```bash [npm]
 npm run vitest-preview
-# 或者
+```
+
+```bash [Yarn]
 yarn vitest-preview
+```
+
+```bash [pnpm]
 pnpm vitest-preview
 ```
+
+:::
 
 然后，执行你插入了 `debug()` 的测试。 测试的 UI 将在 <a href="http://localhost:5006" target="_blank" rel="noreferrer">localhost:5006</a> 打开。


### PR DESCRIPTION
## Summary/ Motivation (TLDR;)

## Related issues

<!-- Add related issue here: E.g: #124-->

- #34 #37

## Features

- [ ] Add `configure` option to custimize vitest preview
- [ ] Add `externalCss` option

## Chores

- [ ] Update website
- [ ] Update CACHE_FOLDER to support multiple vitest preview running at the same time
- [ ] Set chokidar watch options to default (previous: only `snapshotHtmlFile`), since we probably want to watch other files such as `externalCss`
