### PR TITLE
Disable loading vite.config.ts

### DIFF
--- a/packages/vitest-preview/src/node/index.ts
+++ b/packages/vitest-preview/src/node/index.ts
@@ -49,6 +49,7 @@ async function createServer(
 
   const httpServer = http.createServer(app);
   const vite = await createViteServer({
+    configFile: false,
     server: {
       middlewareMode: true,
       host: '0.0.0.0',


### PR DESCRIPTION
## Summary/ Motivation (TLDR;)

I have React Router 7 project which has a `vite.config.ts` at the root and when `vitest-preview` starts, it automatically loads the main application instead of preview dashboard. Providing `configFile: false` will stop `vite` server from auto loading the application `vite.config.ts`.
